### PR TITLE
Restrict user visibility to shared groups

### DIFF
--- a/yunity/users/api.py
+++ b/yunity/users/api.py
@@ -18,12 +18,12 @@ class UserViewSet(viewsets.ModelViewSet):
     Users
 
     # Query parameters
-    - `?search` - search in `display_name`, `first_name` and `last_name`
+    - `?search` - search in `display_name`
     """
-    queryset = get_user_model().objects.all()
+    queryset = get_user_model().objects
     serializer_class = UserSerializer
     filter_backends = (filters.SearchFilter,)
-    search_fields = ('display_name', 'first_name', 'last_name')
+    search_fields = ('display_name',)
 
     def get_permissions(self):
         if self.action == 'create':
@@ -34,3 +34,7 @@ class UserViewSet(viewsets.ModelViewSet):
             self.permission_classes = (IsSameUser,)
 
         return super().get_permissions()
+
+    def get_queryset(self):
+        users_groups = self.request.user.groups.values('id')
+        return self.queryset.filter(groups__in=users_groups)

--- a/yunity/users/serializers.py
+++ b/yunity/users/serializers.py
@@ -6,7 +6,7 @@ class UserSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = get_user_model()
-        fields = ['id', 'display_name', 'first_name', 'last_name', 'email', 'password',
+        fields = ['id', 'display_name', 'email', 'password',
                   'address', 'latitude', 'longitude']
         extra_kwargs = {'password': {'write_only': True}}
 

--- a/yunity/users/tests/test_serializer.py
+++ b/yunity/users/tests/test_serializer.py
@@ -11,5 +11,5 @@ class TestUserSerializer(TestCase):
 
     def test_instantiation(self):
         serializer = UserSerializer(self.user)
-        for k in ['id', 'display_name', 'first_name', 'last_name', 'email']:
+        for k in ['id', 'display_name', 'email']:
             self.assertEqual(serializer.data[k], getattr(self.user, k))

--- a/yunity/users/tests/test_users_api_filter.py
+++ b/yunity/users/tests/test_users_api_filter.py
@@ -1,5 +1,7 @@
 from rest_framework import status
 from rest_framework.test import APITestCase
+
+from yunity.groups.factories import Group
 from yunity.users.factories import User
 
 
@@ -11,6 +13,8 @@ class TestStoresAPIFilter(APITestCase):
 
         cls.user = User()
         cls.user2 = User()
+        cls.group = Group()
+        cls.group.members.add(cls.user, cls.user2)
 
     def test_search_display_name(self):
         self.client.force_login(user=self.user2)


### PR DESCRIPTION
You can only access users which share at least one group with you.