### PR TITLE
Add distinct() parameter

### DIFF
--- a/yunity/users/api.py
+++ b/yunity/users/api.py
@@ -37,4 +37,4 @@ class UserViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         users_groups = self.request.user.groups.values('id')
-        return self.queryset.filter(groups__in=users_groups)
+        return self.queryset.filter(groups__in=users_groups).distinct()

--- a/yunity/users/tests/test_api.py
+++ b/yunity/users/tests/test_api.py
@@ -21,12 +21,10 @@ class TestUsersAPI(APITestCase):
                          'address': faker.address(),
                          'latitude': faker.latitude(),
                          'longitude': faker.longitude()}
-        cls.group = Group()
-        cls.group.members.add(cls.user)
-        cls.group.members.add(cls.user2)
+        cls.group = Group(members=[cls.user, cls.user2])
+        cls.another_common_group = Group(members=[cls.user, cls.user2])
         cls.user_in_another_group = User()
-        cls.another_group = Group()
-        cls.another_group.members.add(cls.user_in_another_group)
+        cls.another_group = Group(members=[cls.user_in_another_group, ])
 
     def test_create_user(self):
         response = self.client.post(self.url, self.user_data, format='json')


### PR DESCRIPTION
Query would return the same user multiple times, one time for each group
that you have in common. Using distinct() reduces this to one result.