### PR TITLE
Fix: store history to record only changed values

### DIFF
--- a/foodsaving/history/tests/test_api.py
+++ b/foodsaving/history/tests/test_api.py
@@ -193,6 +193,7 @@ class TestHistoryAPIWithExistingPickups(PaginatedResponseTestCase):
         self.client.post(self.pickup_url + 'add/')
         response = self.get_results(history_url)
         self.assertEqual(response.data[0]['typus'], 'PICKUP_JOIN')
+        self.assertEqual(parse(response.data[0]['payload']['date']), self.pickup.date)
 
     def test_leave_pickup(self):
         self.client.force_login(self.member)
@@ -200,6 +201,7 @@ class TestHistoryAPIWithExistingPickups(PaginatedResponseTestCase):
         self.client.post(self.pickup_url + 'remove/')
         response = self.get_results(history_url)
         self.assertEqual(response.data[0]['typus'], 'PICKUP_LEAVE')
+        self.assertEqual(parse(response.data[0]['payload']['date']), self.pickup.date)
 
 
 class TestHistoryAPIWithDonePickup(PaginatedResponseTestCase):

--- a/foodsaving/history/tests/test_api.py
+++ b/foodsaving/history/tests/test_api.py
@@ -97,11 +97,15 @@ class TestHistoryAPIWithExistingStore(PaginatedResponseTestCase):
 
     def test_modify_store(self):
         self.client.force_login(self.member)
-        self.client.patch(self.store_url, {'name': 'newnew'})
+        self.client.patch(self.store_url, {
+            'name': 'newnew',  # new value
+            'description': self.store.description  # no change
+        })
         response = self.get_results(history_url)
         self.assertEqual(len(response.data), 1, response.data)
         self.assertEqual(response.data[0]['typus'], 'STORE_MODIFY')
         self.assertEqual(response.data[0]['payload']['name'], 'newnew')
+        self.assertEqual(len(response.data[0]['payload']), 1)
 
     def test_dont_modify_store(self):
         self.client.force_login(self.member)

--- a/foodsaving/stores/models.py
+++ b/foodsaving/stores/models.py
@@ -107,7 +107,6 @@ class PickupDateManager(models.Manager):
         for _ in self.filter(date__lt=timezone.now()):
             # move pickup dates into history, also empty ones
             payload = {}
-            payload['store_name'] = _.store.name
             if _.series:
                 payload['series'] = _.series.id
             if _.max_collectors:

--- a/foodsaving/stores/serializers.py
+++ b/foodsaving/stores/serializers.py
@@ -213,7 +213,7 @@ class StoreSerializer(serializers.ModelSerializer):
                 group=store.group,
                 store=store,
                 user=self.context['request'].user,
-                payload=self.initial_data
+                payload=changed_data
             )
         return store
 

--- a/foodsaving/stores/serializers.py
+++ b/foodsaving/stores/serializers.py
@@ -96,7 +96,7 @@ class PickupDateJoinSerializer(serializers.ModelSerializer):
             group=pickup_date.store.group,
             store=pickup_date.store,
             user=user,
-            payload={'store_name': pickup_date.store.name}
+            payload=PickupDateSerializer(instance=pickup_date).data
         )
         return pickup_date
 
@@ -114,7 +114,7 @@ class PickupDateLeaveSerializer(serializers.ModelSerializer):
             group=pickup_date.store.group,
             store=pickup_date.store,
             user=user,
-            payload={'store_name': pickup_date.store.name}
+            payload=PickupDateSerializer(instance=pickup_date).data
         )
         return pickup_date
 


### PR DESCRIPTION
Before, it showed all values.

This breaks the frontend, as it relies on the store name being present in the payload. Need a workaround there.

It also adds pickup data to join/leave events