### PR TITLE
added commands for run server, test data etc. in dockerfile and readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,11 @@ RUN rm -rf /env; virtualenv -p /usr/bin/python3 /env; bash -c 'source /env/bin/a
 COPY . /foodsaving-backend
 WORKDIR /foodsaving-backend
 RUN cd config; sed 's/fstool-user/root/g; s/fstool-pw/root/g' local_settings.py.example > local_settings.py
-RUN bash -c 'source /env/bin/activate; service postgresql start; python manage.py migrate'; service postgresql stop
+RUN bash -c 'source /env/bin/activate; service postgresql start; service redis-server start; python manage.py migrate; python manage.py create_sample_data >/tmp/create_data; service postgresql stop; service redis-server stop'
 RUN echo 'source /env/bin/activate' >> /root/.bashrc
 
 EXPOSE 8000
 EXPOSE 5432
 # The '0.0.0.0:8000' makes the server listen on 0.0.0.0 instead of 127.0.0.1.
 # It seems docker cannot expose services bound to the loopback interface.
-CMD bash -c 'service postgresql start; service redis-server start; cd /foodsaving-backend; bash'
-
+CMD bash -c 'service postgresql start; service redis-server start; cd /foodsaving-backend; source /env/bin/activate; cat /tmp/create_data; python manage.py runserver 0.0.0.0:8000'

--- a/README.md
+++ b/README.md
@@ -22,25 +22,21 @@ docker build -t backend .
 Run this container, including your most recent source code changes:
 
 ```sh
-docker run -it -p 8000:8000 -v $PWD/foodsaving:/foodsaving-backend/foodsaving backend
+docker run -d -p 8000:8000 -v $PWD/foodsaving:/foodsaving-backend/foodsaving backend
 ```
 
 Note 1: This assumes that your terminal's working directory is in the foodsaving-backend directory, i.e. the directory you cloned from Github.
 Note 2: Only changes you make in the "foodsaving" directory are included.
 
-Once in the container, you can Populate your database with test data:
+The test data are automatically created in the container. You can see log-in details after running this command:
 
 ```sh
-python manage.py create_sample_data
+docker logs -f <container_id_or_name>
 ```
 
 With this data, you can log in as one of the printed e-mail addresses with password 123
 
-Run the server with
-
-```sh
-python manage.py runserver 0.0.0.0:8000
-```
+The server is already running in Docker container.
 
 ## Local install
 ### Install requirements


### PR DESCRIPTION
The dockerfile simplies to run a docker from bash and it is no more necessary to have a docker always open in terminal while doing other things. New commands are now in Dockerfile for test data and runserver.