### PR TITLE
Fix inactive authlogin test

### DIFF
--- a/foodsaving/userauth/serializers.py
+++ b/foodsaving/userauth/serializers.py
@@ -10,9 +10,6 @@ class AuthLoginSerializer(serializers.Serializer):
         credentials = {'email': attrs.get('email'), 'password': attrs.get('password')}
         user = authenticate(**credentials)
         if user:
-            if not user.is_active:
-                msg = 'User account is disabled'
-                raise serializers.ValidationError(msg)
             login(self.context['request'], user)
         else:
             msg = 'Unable to login with provided credentials.'

--- a/foodsaving/userauth/tests/test_api.py
+++ b/foodsaving/userauth/tests/test_api.py
@@ -1,6 +1,7 @@
 from django.contrib import auth
 from rest_framework import status
 from rest_framework.test import APITestCase
+
 from foodsaving.users.factories import UserFactory
 
 
@@ -36,6 +37,7 @@ class TestUserAuthAPI(APITestCase):
     def test_login_as_disabled_user_fails(self):
         data = {'email': self.disabled_user.email, 'password': self.disabled_user.display_name}
         response = self.client.post(self.url, data, format='json')
+        self.assertEqual(response.data['non_field_errors'], ['User account is disabled', ])
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         user = auth.get_user(self.client)
         self.assertFalse(user.is_authenticated())

--- a/foodsaving/userauth/tests/test_api.py
+++ b/foodsaving/userauth/tests/test_api.py
@@ -37,7 +37,7 @@ class TestUserAuthAPI(APITestCase):
     def test_login_as_disabled_user_fails(self):
         data = {'email': self.disabled_user.email, 'password': self.disabled_user.display_name}
         response = self.client.post(self.url, data, format='json')
-        self.assertEqual(response.data['non_field_errors'], ['User account is disabled', ])
+        self.assertEqual(response.data['non_field_errors'], ['Unable to login with provided credentials.', ])
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         user = auth.get_user(self.client)
         self.assertFalse(user.is_authenticated())


### PR DESCRIPTION
`is_active` checking is handled by the authentication backend. The check was never executed.

https://docs.djangoproject.com/en/1.11/ref/contrib/auth/#django.contrib.auth.models.User.is_active