### PR TITLE
Improve email case checking

### DIFF
--- a/foodsaving/users/serializers.py
+++ b/foodsaving/users/serializers.py
@@ -32,6 +32,15 @@ class UserSerializer(serializers.ModelSerializer):
             }
         }
 
+    def validate_email(self, email):
+        action = self.context['view'].action
+        user = self.context['request'].user
+        similar = self.Meta.model.objects.filter_by_similar_email(email)
+        if (action == 'create' and similar.exists())\
+                or (action == 'partial_update' and similar.exclude(id=user.id).exists()):
+            raise serializers.ValidationError(_('Similar e-mail exists: ') + similar.first().email)
+        return email
+
     def create(self, validated_data):
         user = self.Meta.model.objects.create_user(**validated_data)
         return user

--- a/foodsaving/users/tests/test_model.py
+++ b/foodsaving/users/tests/test_model.py
@@ -44,21 +44,6 @@ class TestUserModel(TestCase):
         default_language = get_user_model().objects.create_user(**self.exampleuser).language
         self.assertEqual(default_language, 'en')
 
-    def test_create_user_with_case_sensitive_email_address(self):
-        start = get_user_model().objects.count()
-        get_user_model().objects.create_user(
-            display_name='a',
-            email='fancy@example.com',
-            password='123'
-        )
-        with self.assertRaises(IntegrityError):
-            get_user_model().objects.create_user(
-                display_name='a',
-                email='Fancy@example.com',
-                password='123'
-            )
-        self.assertEqual(get_user_model().objects.count(), start + 1)
-
     def test_create_superuser(self):
         email = faker.email()
         get_user_model().objects.create_superuser(email, 'letmein')


### PR DESCRIPTION
Return error messages if similar cased address exists
Also check on email changes

Closes #372

The checks are better off in the serializer than in the model, because the latter can't return appropriate errors.