### PR TITLE
Ignore email case

### DIFF
--- a/foodsaving/userauth/tests/test_api.py
+++ b/foodsaving/userauth/tests/test_api.py
@@ -9,13 +9,21 @@ class TestUserAuthAPI(APITestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.user = UserFactory()
+        cls.user = UserFactory(email='user98@example.com')
         cls.disabled_user = UserFactory(is_active=False)
         cls.url = '/api/auth/'
 
     def test_login(self):
         data = {'email': self.user.email, 'password': self.user.display_name}
         response = self.client.post(self.url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['email'], self.user.email)
+        user = auth.get_user(self.client)
+        self.assertTrue(user.is_authenticated())
+
+    def test_login_with_similar_email_succeeds(self):
+        data = {'email': 'User98@example.com', 'password': self.user.display_name}
+        response = self.client.post(self.url, data)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data['email'], self.user.email)
         user = auth.get_user(self.client)

--- a/foodsaving/users/api.py
+++ b/foodsaving/users/api.py
@@ -101,8 +101,6 @@ class UserViewSet(
     def reset_password(self, request, pk=None):
         """
         send a request with 'email' to this endpoint to get a new password mailed
-
-        to prevent information leaks, also returns success if the mail doesn't exist
         """
         request_email = request.data.get('email')
         if not request_email:
@@ -111,8 +109,7 @@ class UserViewSet(
         try:
             user = get_user_model().objects.get(email__iexact=request_email)
         except get_user_model().DoesNotExist:
-            # don't leak valid mail addresses
-            return Response(status=status.HTTP_204_NO_CONTENT)
+            return Response(status=status.HTTP_400_BAD_REQUEST)
 
         user.reset_password()
         return Response(status=status.HTTP_204_NO_CONTENT, data={})

--- a/foodsaving/users/api.py
+++ b/foodsaving/users/api.py
@@ -109,7 +109,7 @@ class UserViewSet(
             return Response(status=status.HTTP_400_BAD_REQUEST,
                             data={'error': 'mail address is not provided'})
         try:
-            user = get_user_model().objects.get(email=request_email)
+            user = get_user_model().objects.get(email__iexact=request_email)
         except get_user_model().DoesNotExist:
             # don't leak valid mail addresses
             return Response(status=status.HTTP_204_NO_CONTENT)

--- a/foodsaving/users/models.py
+++ b/foodsaving/users/models.py
@@ -39,6 +39,13 @@ class UserManager(BaseUserManager):
     def filter_by_similar_email(self, email):
         return self.filter(email__iexact=email)
 
+    def get_by_natural_key(self, email):
+        """
+        As we don't allow sign-ups with similarly cased email addresses,
+        we can allow users to login with case spelling mistakes
+        """
+        return self.filter_by_similar_email(email).first()
+
     def _validate_email(self, email):
         if email is None:
             raise ValueError('The email field must be set')

--- a/foodsaving/users/tests/test_api.py
+++ b/foodsaving/users/tests/test_api.py
@@ -368,8 +368,7 @@ class TestPasswordReset(APITestCase):
     def test_reset_password_fails_if_wrong_mail(self):
         response = self.client.post(self.url, {'email': 'wrong@example.com'})
         self.assertIsNone(response.data)
-        # don't leak out validity of mail addresses, therefore return success
-        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(len(mail.outbox), 0)
 
     def test_reset_password_fails_if_no_email(self):


### PR DESCRIPTION
It's a huge UX issue if the user gets locked out because they get their email wrong. At least with case mistakes, we can help out. This PR let's the user login and reset their password with case-insensitive email handling.